### PR TITLE
PlanDefintion and ValueSet profiles hierarchies with US Public Health base.

### DIFF
--- a/input/hl7-fhir-us-ecr.xml
+++ b/input/hl7-fhir-us-ecr.xml
@@ -701,11 +701,29 @@
         </resource>
         <resource>
             <reference>
-                <reference value="StructureDefinition/ersd-valueset"/>
-                <display value="Ersd_ValueSet"/>
+                <reference value="StructureDefinition/us-ph-valueset"/>
+                <display value="US Publish Health ValueSet"/>
             </reference>
-            <name value="Ersd_ValueSet"/>
-            <description value="This profile describes the eRSD value sets."/>
+            <name value="USPublicHealthValueSet"/>
+            <description value="This profile describes the US Public Health value sets."/>
+            <exampleBoolean value="false"/>
+        </resource>
+        <resource>
+            <reference>
+                <reference value="StructureDefinition/ersd-triggering-valueset"/>
+                <display value="eRSD Triggering Value Set"/>
+            </reference>
+            <name value="ERSDTriggeringValueSet"/>
+            <description value="his profile describes the eRSD Triggering value sets."/>
+            <exampleBoolean value="false"/>
+        </resource>
+        <resource>
+            <reference>
+                <reference value="StructureDefinition/ersd-runtimerule-valueset"/>
+                <display value="eRSD Runtime Rule Value Set"/>
+            </reference>
+            <name value="ERSDRuntimeRuleValueSet"/>
+            <description value="his profile describes the eRSD Runtime Rule value sets."/>
             <exampleBoolean value="false"/>
         </resource>
         <resource>

--- a/input/hl7-fhir-us-ecr.xml
+++ b/input/hl7-fhir-us-ecr.xml
@@ -1152,7 +1152,7 @@
         </resource>
         <resource>
             <reference>
-                <reference value="Library/library-RuleFilters-1.0.0"/>
+                <reference value="Library/RuleFilters"/>
                 <display value="Rule Filters"/>
             </reference>
             <name value="Rule Filters"/>
@@ -1162,7 +1162,7 @@
         </resource>
         <resource>
             <reference>
-                <reference value="Library/library-FHIRHelpers-4.0.1"/>
+                <reference value="Library/FHIRHelpers"/>
                 <display value="FHIRHelpers"/>
             </reference>
             <name value="FHIRHelpers"/>
@@ -1172,7 +1172,7 @@
         </resource>
         <resource>
             <reference>
-                <reference value="CodeSystem/codesystem-ersd-usage-context-type"/>
+                <reference value="CodeSystem/ersd-usage-context-type"/>
                 <display value="eRSD Usage Context Type Code System"/>
             </reference>
             <name value="eRSD Usage Context Type Code System"/>
@@ -1181,7 +1181,7 @@
         </resource>
         <resource>
             <reference>
-                <reference value="CodeSystem/codesystem-ersd-endpoint-connection-type"/>
+                <reference value="CodeSystem/ersd-endpoint-connection-type"/>
                 <display value="eRSD Endpoint Connection Type"/>
             </reference>
             <name value="eRSD Endpoint Connection Type"/>
@@ -1190,7 +1190,7 @@
         </resource>
         <resource>
             <reference>
-                <reference value="CodeSystem/codesystem-executabletask-type"/>
+                <reference value="CodeSystem/executabletask-type"/>
                 <display value="Executable Task Types Code System"/>
             </reference>
             <name value="Executable Task Types Code System"/>
@@ -1199,20 +1199,29 @@
         </resource>
         <resource>
             <reference>
-                <reference value="CodeSystem/codesystem-ersd-usage-context"/>
-                <display value="eRSD Usage Context Code System"/>
+                <reference value="CodeSystem/ersd-jurisdictions-example"/>
+                <display value="eRSD Jurisdictions Example"/>
             </reference>
-            <name value="eRSD Usage Context Code System"/>
-            <description value="This code system contains codes that identify the use context of a valueset."/>
+            <name value="ERSDJusdictionsExample"/>
+            <description value="This code system describes jurisdictions that require public health reporting."/>
             <exampleBoolean value="false"/>
         </resource>
         <resource>
             <reference>
-                <reference value="CodeSystem/codesystem-ersd-jurisdiction"/>
-                <display value="eRSD Jurisdictions"/>
+                <reference value="CodeSystem/ersd-jurisdiction-types"/>
+                <display value="eRSD JurisdictionTypes Code System"/>
             </reference>
-            <name value="eRSD Jurisdictions"/>
-            <description value="This code system describes jurisdictions that require public health reporting."/>
+            <name value="ERSDJurisdictionTypes"/>
+            <description value="This code system describes the possible types of jurisdictions that require public health reporting."/>
+            <exampleBoolean value="false"/>
+        </resource>
+        <resource>
+            <reference>
+                <reference value="CodeSystem/ersd-usage-context"/>
+                <display value="eRSD Usage Context Code System"/>
+            </reference>
+            <name value="eRSD Usage Context Code System"/>
+            <description value="This code system contains codes that identify the use context of a valueset."/>
             <exampleBoolean value="false"/>
         </resource>
         <resource>

--- a/input/hl7-fhir-us-ecr.xml
+++ b/input/hl7-fhir-us-ecr.xml
@@ -550,6 +550,15 @@
         </resource>
         <resource>
             <reference>
+                <reference value="StructureDefinition/us-ph-plandefinition"/>
+                <display value="US Public Health PlanDefinition"/>
+            </reference>
+            <name value="USPublicHealthPlanDefinition"/>
+            <description value="This profile describes the US Public Health PlanDefinitions."/>
+            <exampleBoolean value="false"/>
+        </resource>
+        <resource>
+            <reference>
                 <reference value="StructureDefinition/ersd-plandefinition"/>
                 <display value="ersd-plandefinition"/>
             </reference>

--- a/input/resources/codesystem/ersd-endpoint-connection-type.xml
+++ b/input/resources/codesystem/ersd-endpoint-connection-type.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem
     xmlns="http://hl7.org/fhir">
-    <id value="codesystem-ersd-endpoint-connection-type"/>
+    <id value="ersd-endpoint-connection-type"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:07:28.766+00:00"/>
         <source value="#KigvgvLvyZijhe4p"/>
     </meta>
-    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-endpoint-connection-type"/>
+    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-endpoint-connection-type"/>
     <name value="Ersd_CodeSystem_Endpoint_Connection_Type"/>
     <title value="eRSD Endpoint Connection Type"/>
     <status value="active"/>

--- a/input/resources/codesystem/ersd-jurisdiction-types.xml
+++ b/input/resources/codesystem/ersd-jurisdiction-types.xml
@@ -1,0 +1,46 @@
+<CodeSystem xmlns="http://hl7.org/fhir">
+   <id value="ersd-jurisdiction-types"/>
+   <meta>
+      <versionId value="1"/>
+      <lastUpdated value="2020-10-30T21:48:53.841+00:00"/>
+      <source value="#FTnSj0zQY0rNR0jq"/>
+   </meta>
+   <url value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-jurisdiction-types"/>
+   <version value="0.1.0"/>
+   <name value="ERSDJurisdictionTypes"/>
+   <title value="eRSD JurisdictionTypes"/>
+   <status value="active"/>
+   <description value="This code system describes the possible types of jurisdictions that require public health reporting."/>
+   <caseSensitive value="false"/>
+   <content value="complete"/>
+   <!-- <concept>
+      <code value="state"/>
+      <display value="State"/>
+      <definition value="A state-level public health agency/jurisdiction"/>
+   </concept>
+   <concept>
+      <code value="county"/>
+      <display value="County"/>
+      <definition value="A county-level public health agency/jurisdiction"/>
+   </concept>
+   <concept>
+      <code value="city"/>
+      <display value="City"/>
+      <definition value="A city-level public health agency/jurisdiction"/>
+   </concept>
+   <concept>
+      <code value="district"/>
+      <display value="District"/>
+      <definition value="A district-level public health agency/jurisdiction"/>
+   </concept>
+   <concept>
+      <code value="borough"/>
+      <display value="Borough"/>
+      <definition value="A borough-level public health agency/jurisdiction"/>
+   </concept>
+   <concept>
+      <code value="parish"/>
+      <display value="Parish"/>
+      <definition value="A parish/neighborhood-level public health agency/jurisdiction"/>
+   </concept> -->
+</CodeSystem>

--- a/input/resources/codesystem/ersd-jurisdictions-example.xml
+++ b/input/resources/codesystem/ersd-jurisdictions-example.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem
     xmlns="http://hl7.org/fhir">
-    <id value="codesystem-ersd-jurisdiction"/>
+    <id value="ersd-jurisdictions-example"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:07:28.778+00:00"/>
         <source value="#xQrbEpz6eDVX0qc8"/>
     </meta>
-    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-jurisdiction"/>
+    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-jurisdictions-example"/>
     <version value="0.1.0"/>
-    <name value="Ersd_Jurisdictions"/>
-    <title value="eRSD Jurisdictions"/>
+    <name value="ERSDJurisdictionsExample"/>
+    <title value="eRSD Jurisdictions Example"/>
     <status value="active"/>
+    <experimental value="true"/>
     <publisher value="HL7 Public Health Work Group"/>
     <description value="This code system describes jurisdictions that require public health reporting."/>
     <caseSensitive value="false"/>

--- a/input/resources/codesystem/ersd-usage-context-type.xml
+++ b/input/resources/codesystem/ersd-usage-context-type.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem
     xmlns="http://hl7.org/fhir">
-    <id value="codesystem-ersd-usage-context-type"/>
+    <id value="ersd-usage-context-type"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:07:28.764+00:00"/>
         <source value="#qUpSZCH85xsz1g46"/>
     </meta>
-    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-usage-context-type"/>
+    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context-type"/>
     <version value="1.0.0"/>
     <name value="Ersd_CodeSystem_UsageContext_Type"/>
     <title value="eRSD Usage Context Type Code System"/>

--- a/input/resources/codesystem/ersd-usage-context.xml
+++ b/input/resources/codesystem/ersd-usage-context.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem
     xmlns="http://hl7.org/fhir">
-    <id value="codesystem-ersd-usage-context"/>
+    <id value="ersd-usage-context"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:07:28.765+00:00"/>
         <source value="#bsVffARcuC76TdEC"/>
     </meta>
-    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-usage-context"/>
+    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context"/>
     <version value="1.0.0"/>
     <name value="Ersd_CodeSystem_UsageContext"/>
     <title value="eRSD Usage Context Code System"/>

--- a/input/resources/codesystem/executabletask-type.xml
+++ b/input/resources/codesystem/executabletask-type.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeSystem
     xmlns="http://hl7.org/fhir">
-    <id value="codesystem-executabletask-type"/>
+    <id value="executabletask-type"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:07:28.770+00:00"/>
         <source value="#dID131d3EchUhat8"/>
     </meta>
-    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+    <url value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
     <version value="0.1.0"/>
     <name value="CodeSystem_ExecutableTask_Types"/>
     <title value="Executable Task Types Code System"/>

--- a/input/resources/library/FHIRHelpers.xml
+++ b/input/resources/library/FHIRHelpers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Library
     xmlns="http://hl7.org/fhir">
-    <id value="library-FHIRHelpers-4.0.1"/>
+    <id value="FHIRHelpers"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:03:45.650+00:00"/>

--- a/input/resources/library/RuleFilters.xml
+++ b/input/resources/library/RuleFilters.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Library
     xmlns="http://hl7.org/fhir">
-    <id value="library-RuleFilters-1.0.0"/>
+    <id value="RuleFilters"/>
     <meta>
         <versionId value="1"/>
         <lastUpdated value="2020-10-29T02:03:45.660+00:00"/>

--- a/input/resources/plandefinition/plandefinition-ersd-instance.xml
+++ b/input/resources/plandefinition/plandefinition-ersd-instance.xml
@@ -35,7 +35,7 @@
         <textEquivalent value="Start"/>
         <code>
             <coding>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="start"/>
             </coding>
         </code>
@@ -58,7 +58,7 @@
         <action>
             <code>
                 <coding>
-                    <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                    <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                     <code value="check-reportable"/>
                 </coding>
             </code>
@@ -95,7 +95,7 @@
         <textEquivalent value="Create and Report eICR"/>
         <code>
             <coding>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="create-and-report-eicr"/>
             </coding>
         </code>
@@ -143,7 +143,7 @@
         <textEquivalent value="Create eICR."/>
         <code>
             <coding>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="create-eicr"/>
             </coding>
         </code>
@@ -153,7 +153,7 @@
         <textEquivalent value="Validate eICR."/>
         <code>
             <coding>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="validate-eicr"/>
             </coding>
         </code>
@@ -163,7 +163,7 @@
         <textEquivalent value="Route and send eICR"/>
         <code>
             <coding>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="route-and-send-eicr"/>
             </coding>
         </code>
@@ -174,7 +174,7 @@
         <action>
             <code>
                 <coding>
-                    <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                    <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                     <code value="report-eicr"/>
                 </coding>
             </code>

--- a/input/resources/structuredefinition/ersd-computablevalueset.xml
+++ b/input/resources/structuredefinition/ersd-computablevalueset.xml
@@ -47,7 +47,7 @@
     <kind value="resource"/>
     <abstract value="false"/>
     <type value="ValueSet"/>
-    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-valueset"/>
+    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-valueset"/>
     <derivation value="constraint"/>
     <snapshot>
         <element id="ValueSet">

--- a/input/resources/structuredefinition/ersd-executablevalueset.xml
+++ b/input/resources/structuredefinition/ersd-executablevalueset.xml
@@ -47,7 +47,7 @@
     <kind value="resource"/>
     <abstract value="false"/>
     <type value="ValueSet"/>
-    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-valueset"/>
+    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-valueset"/>
     <derivation value="constraint"/>
     <snapshot>
         <element id="ValueSet">

--- a/input/resources/structuredefinition/ersd-plandefinition.xml
+++ b/input/resources/structuredefinition/ersd-plandefinition.xml
@@ -39,7 +39,7 @@
     <kind value="resource"/>
     <abstract value="false"/>
     <type value="PlanDefinition"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/PlanDefinition"/>
+    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-plandefinition"/>
     <derivation value="constraint"/>
     <differential>
         <element id="PlanDefinition">
@@ -47,68 +47,7 @@
             <short value="eRSD - electronic Reporting and Surveillance Distribution"/>
             <definition value="Defines the logic and rules around determining: whether or not a condition is reportable to public health, which jurisdiction(s) is/are responsible, which jurisdiction(s) need to be notified, and if the condition is reportable, gives timing information, next steps and condition information to the clinician."/>
             <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.version">
-            <path value="PlanDefinition.version"/>
-            <short value="Business version of the eRSD"/>
-            <definition value="Business version of the eRSD"/>
-            <min value="1"/>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.name">
-            <path value="PlanDefinition.name"/>
-            <short value="Name for this eRSD (computer friendly)"/>
-            <definition value="Name for this eRSD (computer friendly)"/>
-            <min value="1"/>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.title">
-            <path value="PlanDefinition.title"/>
-            <short value="Title for this eRSD"/>
-            <definition value="Title for this eRSD"/>
-            <min value="1"/>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.type">
-            <path value="PlanDefinition.type"/>
-            <short value="Type of this eRSD"/>
-            <definition value="Type of this eRSD"/>
-            <fixedCodeableConcept>
-                <coding>
-                    <system value="http://terminology.hl7.org/CodeSystem/plan-definition-type"/>
-                    <code value="workflow-definition"/>
-                </coding>
-            </fixedCodeableConcept>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.date">
-            <path value="PlanDefinition.date"/>
-            <short value="Date the eRSD was published"/>
-            <definition value="Date the eRSD was published"/>
-            <min value="1"/>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.publisher">
-            <path value="PlanDefinition.publisher"/>
-            <short value="Name of the agency that published this eRSD"/>
-            <definition value="Name of the agency that published this eRSD"/>
-        </element>
-        <element id="PlanDefinition.effectivePeriod">
-            <path value="PlanDefinition.effectivePeriod"/>
-            <short value="When the eRSD is expected to be used"/>
-            <definition value="The period during which the eRSD is expected to be used"/>
-            <mustSupport value="true"/>
-        </element>
-        <element id="PlanDefinition.effectivePeriod.start">
-            <path value="PlanDefinition.effectivePeriod.start"/>
-            <short value="The start of the time period when this eRSD goes in effect"/>
-            <definition value="The start of the time period when this eRSD goes in effect"/>
-            <min value="1"/>
-        </element>
-        <element id="PlanDefinition.library">
-            <path value="PlanDefinition.library"/>
-            <mustSupport value="true"/>
-        </element>
+        </element>        
         <element id="PlanDefinition.action">
             <path value="PlanDefinition.action"/>
             <slicing>

--- a/input/resources/structuredefinition/ersd-plandefinition.xml
+++ b/input/resources/structuredefinition/ersd-plandefinition.xml
@@ -257,7 +257,7 @@
         <element id="PlanDefinition.action:checkReportable.code">
             <path value="PlanDefinition.action.code"/>
             <code>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="check-reportable"/>
                 <display value="Check if suspected to be reportable and if in progress."/>
             </code>
@@ -373,7 +373,7 @@
         <element id="PlanDefinition.action:createAndReport.code">
             <path value="PlanDefinition.action.code"/>
             <code>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="create-and-report-eicr"/>
                 <display value="Create and report eICR after 24 hours."/>
             </code>
@@ -615,7 +615,7 @@
         <element id="PlanDefinition.action:createEicr.code">
             <path value="PlanDefinition.action.code"/>
             <code>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="create-eicr"/>
                 <display value="eICR construction."/>
             </code>
@@ -639,7 +639,7 @@
         <element id="PlanDefinition.action:validateEicr.code">
             <path value="PlanDefinition.action.code"/>
             <code>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="validate-eicr"/>
                 <display value="Validate EICR after creation."/>
             </code>
@@ -675,7 +675,7 @@
         <element id="PlanDefinition.action:routeAndSendEicr.code">
             <path value="PlanDefinition.action.code"/>
             <code>
-                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-executabletask-type"/>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/executabletask-type"/>
                 <code value="route-and-send-eicr"/>
                 <display value="Route and send EICR after validation."/>
             </code>

--- a/input/resources/structuredefinition/ersd-runtimerule-valueset.xml
+++ b/input/resources/structuredefinition/ersd-runtimerule-valueset.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="ersd-runtimerule-valueset"/>
+    <meta>
+        <versionId value="3"/>
+        <lastUpdated value="2020-10-28T06:46:35.358+00:00"/>
+        <source value="#kndw5Om9L1XTYfwC"/>
+    </meta>
+    <url value="http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-runtimerule-valueset"/>
+    <version value="1.0.0"/>
+    <name value="ERSDRuntimeRuleValueSet"/>
+    <title value="eRSD Runtime Rule Value Set"/>
+    <status value="active"/>
+    <publisher value="HL7 Public Health Work Group"/>
+    <description value="This profile describes the eRSD Runtime Rule value sets."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="RCTC"/>
+        <name value="RCTC Spreadsheet"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="false"/>
+    <type value="ValueSet"/>
+    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-valueset"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="ValueSet">
+            <path value="ValueSet"/>
+        </element>
+        <element id="ValueSet.useContext">
+          <path value="ValueSet.useContext"/>
+          <slicing>
+            <discriminator>
+              <type value="pattern"/>
+              <path value="code"/>
+            </discriminator>
+          </slicing>
+          <!-- net cardinality rules -->
+          <min value="1"/>
+          <max value="1"/>
+        </element>
+        <element id="ValueSet.useContext:reportingContext">
+          <path value="ValueSet.useContext"/>
+          <sliceName value="reportingContext"/>
+          <min value="1"/>
+          <max value="1"/>
+        </element>
+        <element id="ValueSet.useContext:reportingContext.code">
+          <path value="ValueSet.useContext.code"/>
+          <min value="1"/>
+          <max value="1"/>
+          <fixedCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context-type" />
+              <code value="reporting" />
+              <display value="Reporting" />
+            </coding>
+          </fixedCodeableConcept>
+        </element>
+        <element id="ValueSet.useContext:reportingContext.valueCodeableConcept">
+            <path value="ValueSet.useContext.valueCodeableConcept"/>
+            <short value="value set useContext"/>
+            <definition value="The eRSD use context of the value set."/>
+            <min value="1"/>
+            <max value="1"/>
+            <mustSupport value="true"/>
+            <fixedCodeableConcept>
+              <coding>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context" />
+                <code value="runtime-rule" />
+                <display value="Runtime Rule" />
+              </coding>
+            </fixedCodeableConcept>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/input/resources/structuredefinition/ersd-triggering-valueset.xml
+++ b/input/resources/structuredefinition/ersd-triggering-valueset.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition
+    xmlns="http://hl7.org/fhir">
+    <id value="ersd-triggering-valueset"/>
+    <meta>
+        <versionId value="3"/>
+        <lastUpdated value="2020-10-28T06:46:35.358+00:00"/>
+        <source value="#kndw5Om9L1XTYfwC"/>
+    </meta>
+    <url value="http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-triggering-valueset"/>
+    <version value="1.0.0"/>
+    <name value="ERSDTriggeringValueSet"/>
+    <title value="eRSD Triggering Value Set"/>
+    <status value="active"/>
+    <publisher value="HL7 Public Health Work Group"/>
+    <description value="This profile describes the eRSD Triggering value sets."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="RCTC"/>
+        <name value="RCTC Spreadsheet"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="false"/>
+    <type value="ValueSet"/>
+    <baseDefinition value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-valueset"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="ValueSet">
+            <path value="ValueSet"/>
+        </element>
+        <element id="ValueSet.useContext">
+          <path value="ValueSet.useContext"/>
+          <slicing>
+            <discriminator>
+              <type value="pattern"/>
+              <path value="code"/>
+            </discriminator>
+          </slicing>
+          <!-- net cardinality rules -->
+          <min value="1"/>
+          <max value="1"/>
+        </element>
+        <element id="ValueSet.useContext:reportingContext">
+          <path value="ValueSet.useContext"/>
+          <sliceName value="reportingContext"/>
+          <min value="1"/>
+          <max value="1"/>
+        </element>
+        <element id="ValueSet.useContext:reportingContext.code">
+          <path value="ValueSet.useContext.code"/>
+          <min value="1"/>
+          <max value="1"/>
+          <fixedCodeableConcept>
+            <coding>
+              <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context-type" />
+              <code value="reporting" />
+              <display value="Reporting" />
+            </coding>
+          </fixedCodeableConcept>
+        </element>
+        <element id="ValueSet.useContext:reportingContext.valueCodeableConcept">
+            <path value="ValueSet.useContext.valueCodeableConcept"/>
+            <short value="value set useContext"/>
+            <definition value="The eRSD use context of the value set."/>
+            <min value="1"/>
+            <max value="1"/>
+            <mustSupport value="true"/>
+            <fixedCodeableConcept>
+              <coding>
+                <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-usage-context" />
+                <code value="triggering" />
+                <display value="Triggering" />
+              </coding>
+            </fixedCodeableConcept>
+        </element>
+    </differential>
+</StructureDefinition>

--- a/input/resources/structuredefinition/us-ph-plandefinition.xml
+++ b/input/resources/structuredefinition/us-ph-plandefinition.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="us-ph-plandefinition"/>
+    <url value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-plandefinition"/>
+    <version value="1.0.0"/>
+    <name value="USPublicHealthPlanDefinition"/>
+    <title value="US Public Health PlanDefinitions"/>
+    <status value="active"/>
+    <experimental value="false"/>
+    <publisher value="HL7 Public Health Work Group"/>
+    <description value="This profile describes the US Public Health PlanDefinitions."/>
+    <fhirVersion value="4.0.1"/>
+    <mapping>
+        <identity value="workflow"/>
+        <uri value="http://hl7.org/fhir/workflow"/>
+        <name value="Workflow Pattern"/>
+    </mapping>
+    <mapping>
+        <identity value="w5"/>
+        <uri value="http://hl7.org/fhir/fivews"/>
+        <name value="FiveWs Pattern Mapping"/>
+    </mapping>
+    <mapping>
+        <identity value="objimpl"/>
+        <uri value="http://hl7.org/fhir/object-implementation"/>
+        <name value="Object Implementation Information"/>
+    </mapping>
+    <mapping>
+        <identity value="rim"/>
+        <uri value="http://hl7.org/v3"/>
+        <name value="RIM Mapping"/>
+    </mapping>
+    <kind value="resource"/>
+    <abstract value="false"/>
+    <type value="PlanDefinition"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/shareableplandefinition"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="PlanDefinition">
+            <path value="PlanDefinition"/>
+            <short value="US Public Health PlanDefinition"/>
+            <definition value="Defines a shareable US Public Health PlanDefinition."/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.version">
+            <path value="PlanDefinition.version"/>
+            <short value="Business version of the eRSD"/>
+            <definition value="Business version of the eRSD"/>
+            <min value="1"/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.name">
+            <path value="PlanDefinition.name"/>
+            <short value="Name for this eRSD (computer friendly)"/>
+            <definition value="Name for this eRSD (computer friendly)"/>
+            <min value="1"/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.title">
+            <path value="PlanDefinition.title"/>
+            <short value="Title for this eRSD"/>
+            <definition value="Title for this eRSD"/>
+            <min value="1"/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.type">
+            <path value="PlanDefinition.type"/>
+            <short value="Type of this eRSD"/>
+            <definition value="Type of this eRSD"/>
+            <fixedCodeableConcept>
+                <coding>
+                    <system value="http://terminology.hl7.org/CodeSystem/plan-definition-type"/>
+                    <code value="workflow-definition"/>
+                </coding>
+            </fixedCodeableConcept>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.date">
+            <path value="PlanDefinition.date"/>
+            <short value="Date the eRSD was published"/>
+            <definition value="Date the eRSD was published"/>
+            <min value="1"/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.publisher">
+            <path value="PlanDefinition.publisher"/>
+            <short value="Name of the agency that published this eRSD"/>
+            <definition value="Name of the agency that published this eRSD"/>
+        </element>
+        <element id="PlanDefinition.effectivePeriod">
+            <path value="PlanDefinition.effectivePeriod"/>
+            <short value="When the eRSD is expected to be used"/>
+            <definition value="The period during which the eRSD is expected to be used"/>
+            <mustSupport value="true"/>
+        </element>
+        <element id="PlanDefinition.effectivePeriod.start">
+            <path value="PlanDefinition.effectivePeriod.start"/>
+            <short value="The start of the time period when this eRSD goes in effect"/>
+            <definition value="The start of the time period when this eRSD goes in effect"/>
+            <min value="1"/>
+        </element>
+        <element id="PlanDefinition.library">
+            <path value="PlanDefinition.library"/>
+            <mustSupport value="true"/>
+        </element>        
+    </differential>
+</StructureDefinition>

--- a/input/resources/structuredefinition/us-ph-valueset.xml
+++ b/input/resources/structuredefinition/us-ph-valueset.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<StructureDefinition
-    xmlns="http://hl7.org/fhir">
-    <id value="ersd-valueset"/>
-    <meta>
-        <versionId value="3"/>
-        <lastUpdated value="2020-10-28T06:46:35.358+00:00"/>
-        <source value="#kndw5Om9L1XTYfwC"/>
-    </meta>
-    <url value="http://hl7.org/fhir/us/ecr/StructureDefinition/ersd-valueset"/>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="us-ph-valueset"/>
+    <url value="http://hl7.org/fhir/us/ecr/StructureDefinition/us-ph-valueset"/>
     <version value="1.0.0"/>
-    <name value="Ersd_ValueSet"/>
-    <title value="eRSD Value Set"/>
+    <name value="USPublicHealthValueSet"/>
+    <title value="US Public Health Value Set"/>
     <status value="active"/>
     <publisher value="HL7 Public Health Work Group"/>
-    <description value="This profile describes the eRSD value sets."/>
+    <description value="This profile describes the US Public Health value sets."/>
     <fhirVersion value="4.0.1"/>
     <mapping>
         <identity value="RCTC"/>
@@ -22,7 +16,7 @@
     <kind value="resource"/>
     <abstract value="false"/>
     <type value="ValueSet"/>
-    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/ValueSet"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
     <derivation value="constraint"/>
     <differential>
         <element id="ValueSet">
@@ -86,13 +80,15 @@
         </element>
         <element id="ValueSet.name">
             <path value="ValueSet.name"/>
+            <short value="RCTC value set name"/>
+            <definition value="The name of the RCTC value set."/>
             <min value="1"/>
             <mustSupport value="true"/>
         </element>
         <element id="ValueSet.title">
             <path value="ValueSet.title"/>
-            <short value="RCTC value set name"/>
-            <definition value="The name of the RCTC value set."/>
+            <short value="RCTC value set title"/>
+            <definition value="The title of the RCTC value set."/>
             <min value="1"/>
             <mustSupport value="true"/>
             <mapping>

--- a/input/resources/valueset/valueset-ersd-endpoint-connection-type.xml
+++ b/input/resources/valueset/valueset-ersd-endpoint-connection-type.xml
@@ -28,7 +28,7 @@
             <system value="http://terminology.hl7.org/CodeSystem/endpoint-connection-type"/>
         </include>
         <include>
-            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-endpoint-connection-type"/>
+            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-endpoint-connection-type"/>
         </include>
     </compose>
     <expansion>
@@ -104,12 +104,12 @@
             <display value="Direct Project"/>
         </contains>
         <contains>
-            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-endpoint-connection-type"/>
+            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-endpoint-connection-type"/>
             <code value="hl7-fhir-files"/>
             <display value="HL7 FHIR Files"/>
         </contains>
         <contains>
-            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/codesystem-ersd-endpoint-connection-type"/>
+            <system value="http://hl7.org/fhir/us/ecr/CodeSystem/ersd-endpoint-connection-type"/>
             <code value="hl7-cql-files"/>
             <display value="HL7 CQL Files"/>
         </contains>


### PR DESCRIPTION
- Added USPublicHealthValueSet - derives from base ShareableValueSet
-- Added ERSDTriggeringValueSet (previously ERSDValueset)  - derives from USPublicHealthValueSet
-- Added ERSDRuntimeRuleValueSet - derives from USPublicHealthValueSet

- Added USPublicHealthPlanDefinition - derives from base ShareablePlanDefinition
-- Modified ERSDPlanDefinition - derives from USPublicHealthPlanDefinition

Changed CodeSystem names and IDs - removed "codesystem" prefix